### PR TITLE
Fix responses

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// Version is the semantic version of this library.
-	Version = "0.1.1"
+	Version = "0.1.2"
 )
 
 // Bot encapsulates all the data needed to interact with Slack.
@@ -68,6 +68,10 @@ func (bot *Bot) Start() error {
 	}
 	bot.Name = self["name"].(string)
 	bot.ID = self["id"].(string)
+	log.WithFields(log.Fields{
+		"id":   bot.ID,
+		"name": bot.Name,
+	}).Info("bot authenticated")
 	return bot.connect(websocketURL)
 }
 

--- a/respond.go
+++ b/respond.go
@@ -18,15 +18,18 @@ func Respond(text string) BotAction {
 // RespondRegexp functions exactly as Respond, but instead takes a compiled
 // regexp instead of a string.
 func (bot *Bot) RespondRegexp(re *regexp.Regexp, handler BotAction) {
-	namePattern := fmt.Sprintf("\\A%s|<@%s>:? ", bot.Name, bot.ID)
-	nameRe := regexp.MustCompile(namePattern)
 	closure := func(self *Bot, event map[string]interface{}) (*Message, Status) {
+		name := regexp.MustCompile(fmt.Sprintf("\\A%s:? ", self.Name))
+		id := regexp.MustCompile(fmt.Sprintf("\\A<@%s>:? ", self.ID))
 		text := event["text"].(string)
-		match := nameRe.FindStringIndex(text)
+		match := name.FindStringIndex(text)
 		if match == nil {
-			return nil, Continue
+			match = id.FindStringIndex(text)
+			if match == nil {
+				return nil, Continue
+			}
 		}
-		unmatchedText := text[match[1]+1:]
+		unmatchedText := text[match[1]:]
 		if re.MatchString(unmatchedText) {
 			return handler(self, event)
 		}


### PR DESCRIPTION
- regex needed to be inside the closure, since bot would not have an ID or Name
  when the Respond helper was called
- for some reason, using separate regexes for checking by name or by id works.
  :shrug:
- don't need to offset the match by 1
