### PR TITLE
add struct to represent more info about users

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -20,7 +20,7 @@ type Bot struct {
 	ID           string
 	Handlers     map[string]([]BotAction)
 	Subhandlers  map[string](map[string]([]BotAction))
-	Users        map[string]string
+	Users        map[string]*User
 	Channels     map[string]string
 	reconnectURL string
 }
@@ -33,7 +33,7 @@ func NewBot(token string) *Bot {
 		ID:           "",
 		Handlers:     make(map[string]([]BotAction)),
 		Subhandlers:  make(map[string](map[string]([]BotAction))),
-		Users:        make(map[string]string),
+		Users:        make(map[string]*User),
 		Channels:     make(map[string]string),
 		reconnectURL: "",
 	}
@@ -70,11 +70,9 @@ func (bot *Bot) Start() error {
 	}
 	users := payload["users"].([]interface{})
 	for _, userMap := range users {
-		user := userMap.(map[string]interface{})
-		userID := user["id"].(string)
-		userName := user["name"].(string)
-		bot.Users[userName] = userID
-		bot.Users[userID] = userName
+		user := UserFromJSON(userMap.(map[string]interface{}))
+		bot.Users[user.Nick] = user
+		bot.Users[user.ID] = user
 	}
 	bot.Name = self["name"].(string)
 	bot.ID = self["id"].(string)

--- a/direct_message.go
+++ b/direct_message.go
@@ -27,7 +27,7 @@ func (bot *Bot) OpenDirectMessage(userID string) (string, error) {
 	}
 	success := payload["ok"].(bool)
 	if !success {
-		logOpenDMError(payload, userID, bot.Users[userID])
+		logOpenDMError(payload, userID, bot.Users[userID].Nick)
 		return "", &Error{"could not open direct message"}
 	}
 	channel := payload["channel"].(map[string]interface{})

--- a/direct_message.go
+++ b/direct_message.go
@@ -27,7 +27,12 @@ func (bot *Bot) OpenDirectMessage(userID string) (string, error) {
 	}
 	success := payload["ok"].(bool)
 	if !success {
-		logOpenDMError(payload, userID, bot.Users[userID].Nick)
+		var nick string
+		user, ok := bot.Users[userID]
+		if ok {
+			nick = user.Nick
+		}
+		logOpenDMError(payload, userID, nick)
 		return "", &Error{"could not open direct message"}
 	}
 	channel := payload["channel"].(map[string]interface{})

--- a/user.go
+++ b/user.go
@@ -1,0 +1,32 @@
+package slack
+
+type User struct {
+	ID        string
+	Nick      string
+	FirstName string
+	LastName  string
+}
+
+func (user *User) FullName() (fullName string) {
+	fullName = user.FirstName
+	if user.LastName != "" {
+		fullName += " " + user.LastName
+	}
+	return
+}
+
+func UserFromJSON(data map[string]interface{}) *User {
+	id := data["id"].(string)
+	nick := data["name"].(string)
+
+	profile := data["profile"].(map[string]interface{})
+	firstName := profile["first_name"].(string)
+	lastName := profile["last_name"].(string)
+
+	return &User{
+		ID:        id,
+		Nick:      nick,
+		FirstName: firstName,
+		LastName:  lastName,
+	}
+}

--- a/user.go
+++ b/user.go
@@ -10,7 +10,10 @@ type User struct {
 func (user *User) FullName() (fullName string) {
 	fullName = user.FirstName
 	if user.LastName != "" {
-		fullName += " " + user.LastName
+		if user.FirstName != "" {
+			fullName += " "
+		}
+		fullName += user.LastName
 	}
 	return
 }

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,67 @@
+package slack
+
+import (
+	"testing"
+)
+
+func assert(condition bool, t *testing.T) {
+	if !condition {
+		t.Error("Error.")
+	}
+}
+
+func TestFullName(t *testing.T) {
+	var tests = []struct {
+		firstName string
+		lastName  string
+		fullName  string
+	}{
+		{
+			firstName: "Foo",
+			lastName:  "Bar",
+			fullName:  "Foo Bar",
+		},
+		{
+			firstName: "",
+			lastName:  "Bar",
+			fullName:  "Bar",
+		},
+		{
+			firstName: "Foo",
+			lastName:  "",
+			fullName:  "Foo",
+		},
+		{
+			firstName: "",
+			lastName:  "",
+			fullName:  "",
+		},
+	}
+
+	for _, test := range tests {
+		user := &User{
+			ID:        "",
+			Nick:      "",
+			FirstName: test.firstName,
+			LastName:  test.lastName,
+		}
+		assert(user.FullName() == test.fullName, t)
+	}
+}
+
+func TestUserFromJSON(t *testing.T) {
+	data := map[string]interface{}{
+		"id":   "12345",
+		"name": "mynick",
+		"profile": map[string]interface{}{
+			"first_name": "Foo",
+			"last_name":  "Bar",
+		},
+	}
+
+	user := UserFromJSON(data)
+	assert(user.ID == "12345", t)
+	assert(user.Nick == "mynick", t)
+	assert(user.FirstName == "Foo", t)
+	assert(user.LastName == "Bar", t)
+}


### PR DESCRIPTION
- change Users dict to point slack IDs and nicks to User structs
- update direct messaging to use the new User struct
- update user loading on startup to user new User struct

this relates to #28, cc-ing @a-johnston
